### PR TITLE
accept C99 C-files (including C++-style comments)

### DIFF
--- a/version_manager/MakeMEX.m
+++ b/version_manager/MakeMEX.m
@@ -242,7 +242,7 @@ function CompileCFiles(cfiles, clibfiles, hlibfiles, mexdirectory)
     for Count = 1:numel(cfiles)
         fprintf('\t compiling %s \n', cfiles{Count});
         try
-        eval(['mex ', cfiles{Count}, ' ', LibraryFiles, ' -outdir ', mexdirectory, IncludeDirectories]);
+        eval(['mex CFLAGS="\$CFLAGS -std=c99" ', cfiles{Count}, ' ', LibraryFiles, ' -outdir ', mexdirectory, IncludeDirectories]);
         catch
             warning(['Unable to build mex file for ' cfiles{Count}]);
         end


### PR DESCRIPTION
See http://ch.mathworks.com/matlabcentral/answers/8870-c-comments-in-mex-files-under-linux